### PR TITLE
Prepend startup options bazel command

### DIFF
--- a/internal/bazel_client.go
+++ b/internal/bazel_client.go
@@ -134,7 +134,7 @@ func (b bazelClient) performBazelQuery(query string) ([]*Target, error) {
 		cmd = append(cmd, "--noshow_progress")
 		cmd = append(cmd, "--noshow_loading_progress")
 	}
-	//cmd = append(cmd, b.startupOptions...)
+	b.bazel.SetStartupArgs(b.startupOptions)
 	cmd = append(cmd, "--order_output=no")
 	if b.keepGoing {
 		cmd = append(cmd, "--keep_going")


### PR DESCRIPTION
Adding startup options _before_ the actual bazel command.