### PR TITLE
Add conditional around SetStartupArgs

### DIFF
--- a/internal/bazel_client.go
+++ b/internal/bazel_client.go
@@ -134,7 +134,9 @@ func (b bazelClient) performBazelQuery(query string) ([]*Target, error) {
 		cmd = append(cmd, "--noshow_progress")
 		cmd = append(cmd, "--noshow_loading_progress")
 	}
-	b.bazel.SetStartupArgs(b.startupOptions)
+	if b.startupOptions[0] != "" {
+		b.bazel.SetStartupArgs(b.startupOptions)
+	}
 	cmd = append(cmd, "--order_output=no")
 	if b.keepGoing {
 		cmd = append(cmd, "--keep_going")


### PR DESCRIPTION
-If startup options aren't set, the differ currently crashes. This
change fixes the issue