### PR TITLE
quote targets

### DIFF
--- a/internal/bazel_client.go
+++ b/internal/bazel_client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -118,7 +117,7 @@ func (b bazelClient) processBazelSourcefileTargets(targets []*Target,
 }
 
 func (b bazelClient) performBazelQuery(query string) ([]*Target, error) {
-	file, err := ioutil.TempFile("", ".txt")
+	file, err := os.CreateTemp("", ".txt")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/bazel_client.go
+++ b/internal/bazel_client.go
@@ -72,7 +72,7 @@ func (b bazelClient) QueryTarget(queryTemplate string, targets map[string]bool) 
 
 	var targetKeys []string
 	for k := range targets {
-		targetKeys = append(targetKeys, k)
+		targetKeys = append(targetKeys, "'"+k+"'")
 	}
 
 	var tpl bytes.Buffer

--- a/internal/bazel_sourcefile_target.go
+++ b/internal/bazel_sourcefile_target.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -28,7 +27,7 @@ func NewBazelSourceFileTarget(name string, digest []byte, workingDirectory strin
 		sourceFile := path.Join(workingDirectory, filenamePath)
 		if _, err := os.Stat(sourceFile); !errors.Is(err, os.ErrNotExist) {
 			// path/to/whatever does not exist
-			contents, err := ioutil.ReadFile(sourceFile)
+			contents, err := os.ReadFile(sourceFile)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/io_utils.go
+++ b/internal/io_utils.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -30,7 +29,7 @@ func WriteTargetsFile(targets map[string]bool, output string) {
 
 func ReadHashFile(filename string) (map[string]string, error) {
 	x := map[string]string{}
-	startingContent, err := ioutil.ReadFile(filename)
+	startingContent, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, nil
 	}
@@ -54,7 +53,7 @@ func WriteHashFile(filename string, data interface{}) (string, error) {
 		return "", err
 	}
 
-	err = ioutil.WriteFile(filename, out.Bytes(), 0644)
+	err = os.WriteFile(filename, out.Bytes(), 0644)
 	if err != nil {
 		return "", err
 	}

--- a/internal/proto_delimited_test.go
+++ b/internal/proto_delimited_test.go
@@ -2,12 +2,12 @@ package internal
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestDelimitedReader(t *testing.T) {
-	protoBytes, err := ioutil.ReadFile("query.protodelim")
+	protoBytes, err := os.ReadFile("query.protodelim")
 	if err != nil {
 		t.Errorf("Error reading file")
 	}


### PR DESCRIPTION
Some characters (such as `+`) are valid in target names but need to be escaped when in a query file.